### PR TITLE
Update device spoofed to one that is modern

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -20,9 +20,9 @@ API_URL = "https://api.crunchyroll.com"
 # Fake headers don't seem necessary
 # API_HEADERS = {'User-Agent':"Mozilla/5.0 (iPhone; iPhone OS 8.3.0; en_US)", 'Accept-Encoding':"gzip, deflate", 'Accept':"*/*", 'Content-Type':"application/x-www-form-urlencoded"}
 API_HEADERS = {}
-API_VERSION = "2313.8"
-API_ACCESS_TOKEN = "QWjz212GspMHH9h"
-API_DEVICE_TYPE = "com.crunchyroll.iphone"
+API_VERSION = "2.1.6"
+API_ACCESS_TOKEN = "Scwg9PRRZ19iVwD"
+API_DEVICE_TYPE = "com.crunchyroll.crunchyroid"
 MANGA_API_URL = "https://api-manga.crunchyroll.com"
 MANGA_API_VERSION = "1.0"
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ A: You can configure this on the Crunchyroll website. Go to your [Account Settin
 Changes
 =======
 v2.3.2
+* Update spoofed device
+
+v2.3.2
 * Minor changes
 
 v2.3.1

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A: You can configure this on the Crunchyroll website. Go to your [Account Settin
 
 Changes
 =======
-v2.3.2
+v2.3.3
 * Update spoofed device
 
 v2.3.2


### PR DESCRIPTION
This fixes a bug whereas the app won't even load. Presumably Crunchyroll disallowed the old device which was being spoofed, I just updated it to the latest Android one.